### PR TITLE
Fix default hostname setup

### DIFF
--- a/3/debian-10/docker-compose.yml
+++ b/3/debian-10/docker-compose.yml
@@ -11,12 +11,10 @@ services:
   opencart:
     image: 'docker.io/bitnami/opencart:3-debian-10'
     ports:
-      - '8080:8080'
-      - '8443:8443'
+      - '80:8080'
+      - '443:8443'
     environment:
       - OPENCART_HOST=localhost
-      - OPENCART_EXTERNAL_HTTP_PORT=8080
-      - OPENCART_EXTERNAL_HTTPS_PORT=8443
       - OPENCART_DATABASE_HOST=mariadb
       - OPENCART_DATABASE_PORT_NUMBER=3306
       - OPENCART_DATABASE_USER=bn_opencart

--- a/3/debian-10/docker-compose.yml
+++ b/3/debian-10/docker-compose.yml
@@ -11,10 +11,12 @@ services:
   opencart:
     image: 'docker.io/bitnami/opencart:3-debian-10'
     ports:
-      - '80:8080'
-      - '443:8443'
+      - '8080:8080'
+      - '8443:8443'
     environment:
       - OPENCART_HOST=localhost
+      - OPENCART_EXTERNAL_HTTP_PORT=8080
+      - OPENCART_EXTERNAL_HTTPS_PORT=8443
       - OPENCART_DATABASE_HOST=mariadb
       - OPENCART_DATABASE_PORT_NUMBER=3306
       - OPENCART_DATABASE_USER=bn_opencart

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
@@ -152,6 +152,8 @@ opencart_initialize() {
             info "Upgrading database schema"
             opencart_upgrade
         fi
+        info "Updating Opencart hostname"
+        opencart_update_hostname "${OPENCART_HOST:-localhost}"
 
         info "Persisting OpenCart installation"
         persist_app "$app_name" "$OPENCART_DATA_TO_PERSIST"
@@ -348,4 +350,27 @@ opencart_protect_storage_dir() {
     cp -rp "${OPENCART_BASE_DIR}/system/storage/"* "$OPENCART_STORAGE_DIR"
     opencart_conf_set DIR_STORAGE "${OPENCART_STORAGE_DIR}/"
     opencart_conf_set DIR_STORAGE "${OPENCART_STORAGE_DIR}/" "$OPENCART_ADMIN_CONF_FILE"
+}
+
+########################
+# Update Opencart hostname
+# Globals:
+#   OPENCART_*
+# Arguments:
+#   $1 - PHP constant name
+# Returns:
+#   None
+#########################
+opencart_update_hostname() {
+    local -r hostname="${1:?missing hostname}"
+
+    # Set URL store configuration file
+    opencart_conf_set HTTP_SERVER "http://${hostname}/"
+    opencart_conf_set HTTPS_SERVER "https://${hostname}/"
+
+    # Set URL in admin configuration file
+    opencart_conf_set HTTP_SERVER "http://${hostname}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTP_CATALOG "http://${hostname}/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTPS_SERVER "https://${hostname}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTPS_CATALOG "https://${hostname}/" "$OPENCART_ADMIN_CONF_FILE"
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
@@ -357,7 +357,7 @@ opencart_protect_storage_dir() {
 # Globals:
 #   OPENCART_*
 # Arguments:
-#   $1 - PHP constant name
+#   $1 - hostname in the form <host>[:<port>]
 # Returns:
 #   None
 #########################

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
@@ -363,14 +363,18 @@ opencart_protect_storage_dir() {
 #########################
 opencart_update_hostname() {
     local -r hostname="${1:?missing hostname}"
+    local http_port
+    local https_port
+    http_port_suffix="$([[ "$OPENCART_EXTERNAL_HTTP_PORT" = "80" ]] && echo "" || echo ":$OPENCART_EXTERNAL_HTTP_PORT")"
+    https_port_suffix="$([[ "$OPENCART_EXTERNAL_HTTPS_PORT" = "443" ]] && echo "" || echo ":$OPENCART_EXTERNAL_HTTPS_PORT")"
 
     # Set URL store configuration file
-    opencart_conf_set HTTP_SERVER "http://${hostname}/"
-    opencart_conf_set HTTPS_SERVER "https://${hostname}/"
+    opencart_conf_set HTTP_SERVER "http://${hostname}${http_port_suffix}/"
+    opencart_conf_set HTTPS_SERVER "https://${hostname}${https_port_suffix}/"
 
     # Set URL in admin configuration file
-    opencart_conf_set HTTP_SERVER "http://${hostname}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-    opencart_conf_set HTTP_CATALOG "http://${hostname}/" "$OPENCART_ADMIN_CONF_FILE"
-    opencart_conf_set HTTPS_SERVER "https://${hostname}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-    opencart_conf_set HTTPS_CATALOG "https://${hostname}/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTP_SERVER "http://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTP_CATALOG "http://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTPS_SERVER "https://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+    opencart_conf_set HTTPS_CATALOG "https://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/opencart-env.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/opencart-env.sh
@@ -20,6 +20,8 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 opencart_env_vars=(
     OPENCART_DATA_TO_PERSIST
     OPENCART_HOST
+    OPENCART_EXTERNAL_HTTP_PORT
+    OPENCART_EXTERNAL_HTTPS_PORT
     OPENCART_ENABLE_HTTPS
     OPENCART_SKIP_BOOTSTRAP
     OPENCART_USERNAME
@@ -63,6 +65,8 @@ export OPENCART_DATA_TO_PERSIST="${OPENCART_DATA_TO_PERSIST:-config.php admin/co
 
 # OpenCart configuration
 export OPENCART_HOST="${OPENCART_HOST:-}" # only used during the first initialization
+export OPENCART_EXTERNAL_HTTP_PORT="${OPENCART_EXTERNAL_HTTP_PORT:-80}" # only used during the first initialization
+export OPENCART_EXTERNAL_HTTPS_PORT="${OPENCART_EXTERNAL_HTTPS_PORT:-443}" # only used during the first initialization
 export OPENCART_ENABLE_HTTPS="${OPENCART_ENABLE_HTTPS:-no}" # only used during the first initialization
 export OPENCART_SKIP_BOOTSTRAP="${OPENCART_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 

--- a/3/debian-10/rootfs/opt/bitnami/scripts/opencart/updatehost.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/opencart/updatehost.sh
@@ -15,12 +15,4 @@ set -o pipefail
 
 DOMAIN="${1:?missing host}"
 
-# Set URL store configuration file
-opencart_conf_set HTTP_SERVER "http://${DOMAIN}/"
-opencart_conf_set HTTPS_SERVER "https://${DOMAIN}/"
-
-# Set URL in admin configuration file
-opencart_conf_set HTTP_SERVER "http://${DOMAIN}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-opencart_conf_set HTTP_CATALOG "http://${DOMAIN}/" "$OPENCART_ADMIN_CONF_FILE"
-opencart_conf_set HTTPS_SERVER "https://${DOMAIN}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-opencart_conf_set HTTPS_CATALOG "https://${DOMAIN}/" "$OPENCART_ADMIN_CONF_FILE"
+opencart_update_hostname "$DOMAIN"

--- a/README.md
+++ b/README.md
@@ -224,12 +224,14 @@ Available environment variables:
 
 ##### User and Site configuration
 
-- `APACHE_HTTP_PORT_NUMBER`: Port used by Apache for HTTP. Default: **8080**
-- `APACHE_HTTPS_PORT_NUMBER`: Port used by Apache for HTTPS. Default: **8443**
+- `APACHE_HTTP_PORT_NUMBER`: Port to bind by Apache for HTTP. Default: **8080**
+- `APACHE_HTTPS_PORT_NUMBER`: Port to bind by Apache for HTTPS. Default: **8443**
 - `OPENCART_USERNAME`: OpenCart application username. Default: **user**
 - `OPENCART_PASSWORD`: OpenCart application password. Default: **bitnami**
 - `OPENCART_EMAIL`: OpenCart application email. Default: **user@example.com**
 - `OPENCART_HOST`: OpenCart server hostname/address.
+- `OPENCART_EXTERNAL_HTTP_PORT`: Port to used by OpenCart to generate URLs and links when accessing using HTTP. Default **80**.
+- `OPENCART_EXTERNAL_HTTPS_PORT`: Port to used by OpenCart to generate URLs and links when accessing using HTTPS. Default **443**.
 - `OPENCART_ENABLE_HTTPS`: Whether to use HTTPS by default. Default: **no**.
 - `OPENCART_SKIP_BOOTSTRAP`: Whether to perform initial bootstrapping for the application. Default: **no**
 


### PR DESCRIPTION
**Description of the change**

This PR ensure the "update hostname" function is called during the initialisation to avoid a wrong configuration in the `HTTPS_SERVER` and `HTTPS_CATALOG` settings.

**Benefits**

Valid default configuration.

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/bitnami-docker-opencart/issues/55
