### PR TITLE
Avoid using HTTPS for admin panel when it's disabled

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
@@ -370,14 +370,20 @@ opencart_update_hostname() {
 
     # Set URL store configuration file
     opencart_conf_set HTTP_SERVER "http://${hostname}${http_port_suffix}/"
-    is_boolean_yes "$OPENCART_ENABLE_HTTPS" && opencart_conf_set HTTPS_SERVER "https://${hostname}${https_port_suffix}/"
-
+    if is_boolean_yes "$OPENCART_ENABLE_HTTPS"; then
+        opencart_conf_set HTTPS_SERVER "https://${hostname}${https_port_suffix}/"
+    else
+        opencart_conf_set HTTPS_SERVER "http://${hostname}${http_port_suffix}/"
+    fi
     # Set URL in admin configuration file
     opencart_conf_set HTTP_SERVER "http://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-    opencart_conf_set HTTP_CATALOG "http://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
-    is_boolean_yes "$OPENCART_ENABLE_HTTPS" && opencart_conf_set HTTPS_SERVER "https://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-    is_boolean_yes "$OPENCART_ENABLE_HTTPS" && opencart_conf_set HTTPS_CATALOG "https://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
-
-    # Avoid exit code of previous commands to affect the result of this function
-    true
+    opencart_conf_set HTTP_CATALOG "http://${hostname}${http_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
+    if is_boolean_yes "$OPENCART_ENABLE_HTTPS"; then
+        opencart_conf_set HTTPS_SERVER "https://${hostname}${https_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+        opencart_conf_set HTTPS_CATALOG "https://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
+    else
+        opencart_conf_set HTTPS_SERVER "http://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+        opencart_conf_set HTTPS_CATALOG "http://${hostname}${http_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
+    fi
 }
+

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libopencart.sh
@@ -370,11 +370,14 @@ opencart_update_hostname() {
 
     # Set URL store configuration file
     opencart_conf_set HTTP_SERVER "http://${hostname}${http_port_suffix}/"
-    opencart_conf_set HTTPS_SERVER "https://${hostname}${https_port_suffix}/"
+    is_boolean_yes "$OPENCART_ENABLE_HTTPS" && opencart_conf_set HTTPS_SERVER "https://${hostname}${https_port_suffix}/"
 
     # Set URL in admin configuration file
     opencart_conf_set HTTP_SERVER "http://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
     opencart_conf_set HTTP_CATALOG "http://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
-    opencart_conf_set HTTPS_SERVER "https://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
-    opencart_conf_set HTTPS_CATALOG "https://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
+    is_boolean_yes "$OPENCART_ENABLE_HTTPS" && opencart_conf_set HTTPS_SERVER "https://${hostname}${http_port_suffix}/admin/" "$OPENCART_ADMIN_CONF_FILE"
+    is_boolean_yes "$OPENCART_ENABLE_HTTPS" && opencart_conf_set HTTPS_CATALOG "https://${hostname}${https_port_suffix}/" "$OPENCART_ADMIN_CONF_FILE"
+
+    # Avoid exit code of previous commands to affect the result of this function
+    true
 }


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR ensures HTTP is used for Admin Panel when `OPENCART_ENABLE_HTTPS=no`

**Benefits**

Opencart admin panel is configured to HTTP/HTTPS based on that env. variable.

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/bitnami-docker-opencart/issues/90
